### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+- '4'
+script:
+- npm run lint

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "textlint": "^5.5.0",
-    "textlint-checker-for-vuejs-jp-docs": "git@github.com:vuejs-jp/textlint-checker-for-vuejs-jp-docs.git",
+    "textlint-checker-for-vuejs-jp-docs": "git://github.com/vuejs-jp/textlint-checker-for-vuejs-jp-docs.git",
     "textlint-rule-preset-jtf-style": "^2.1.2"
   },
   "scripts": {


### PR DESCRIPTION
便利かなと思い、travisを追加しました。 
(私のPC(Windows)で、デフォルトでは、npm run lintが走らなかったので。。。)
もしよろしければ、ご利用ください。

また、Travisにてエラーだったため、package.jsonのtextlint-checker-for-vuejs-jp-docsのリンクを修正しました。
https://travis-ci.org/sapics/jp.vuejs.org/builds/135208319

構文エラーの時：https://travis-ci.org/sapics/jp.vuejs.org/builds/135208801
構文エラーが無かった時：https://travis-ci.org/sapics/jp.vuejs.org/builds/135209586
