### PR TITLE
add textlint-rule-no-mix-dearu-desumasu

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -10,6 +10,7 @@
             "4.2.7.コロン(：)": false,
             "4.3.1.丸かっこ（）": false,
             "4.3.2.大かっこ［］": false,
-        }
+        },
+        "no-mix-dearu-desumasu": true,
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "textlint": "^5.5.0",
     "textlint-checker-for-vuejs-jp-docs": "git@github.com:vuejs-jp/textlint-checker-for-vuejs-jp-docs.git",
+    "textlint-rule-no-mix-dearu-desumasu": "^3.0.2",
     "textlint-rule-preset-jtf-style": "^2.1.2"
   },
   "scripts": {


### PR DESCRIPTION
翻訳のゆらぎ & トーン「文体」に対する一つの解決策として、`textlint-rule-no-mix-dearu-desumasu`を追加してみました。
