### PR TITLE
fixed link to hexo.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 このリポジトリは Vue.js 最新バージョン向けのドキュメントを管理しているレポジトリです。
 (Vue.js 0.12 向けのドキュメントを管理しているリポジトリは[こちら](https://github.com/vuejs-jp/012-jp.vuejs.org))
 
-このサイトは [hexo](http://zespia.tw/hexo) で構築されています。サイトコンテンツは `src` の位置に markdown フォーマットで書かれています。プルリクエスト、歓迎します！
+このサイトは [hexo](https://hexo.io/) で構築されています。サイトコンテンツは `src` の位置に markdown フォーマットで書かれています。プルリクエスト、歓迎します！
 
 ## 貢献ガイド
 [Vue.js 公式サイト日本語翻訳ガイド](https://github.com/vuejs/jp.vuejs.org/blob/lang-ja/CONTRIBUTING.md) を一読お願いします！


### PR DESCRIPTION
hexo へはられていたリンク先 http://zespia.tw/hexo が not found になっていたため、 https://hexo.io/ に修正しました。
