### PR TITLE
GitHubの大文字小文字を修正

### DIFF
--- a/src/examples/commits.md
+++ b/src/examples/commits.md
@@ -4,6 +4,6 @@ type: examples
 order: 1
 ---
 
-> この例は最新の Vue.js コミットデータを Github API から取得し、そしてそれらをリストとして表示します。あなたは master ブランチと dev ブランチ間を切り替えることができます。
+> この例は最新の Vue.js コミットデータを GitHub API から取得し、そしてそれらをリストとして表示します。あなたは master ブランチと dev ブランチ間を切り替えることができます。
 
 <iframe width="100%" height="500" src="https://jsfiddle.net/yyx990803/7sekr893/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>

--- a/src/guide/join.md
+++ b/src/guide/join.md
@@ -14,7 +14,7 @@ Vue コミュニティは驚くべき速さで成長しています、そして�
 
 - [フォーラム](http://forum.vuejs.org/): Vue について回答を得たり、そのエコシステムについて質問するために最適な場所です。
 - [Gitter Channel](https://gitter.im/vuejs/vue): 開発者とチャットするための場所です。ここで質問することもできますが、議論がスレッド化されているのであればフォーラムの方がプラットフォームとして適切です。
-- [Github](https://github.com/vuejs): 報告すべきバグや要請したい仕様があれば、GitHub issues が最適です。プルリクエストも歓迎します！
+- [GitHub](https://github.com/vuejs): 報告すべきバグや要請したい仕様があれば、GitHub issues が最適です。プルリクエストも歓迎します！
 
 ### エコシステムを調べる
 


### PR DESCRIPTION
2.0のドキュメントにて、「GitHub」の表記が「Git**h**ub」となっている箇所を見つけたため、修正いたしました。