### PR TITLE
Upgrade Node.js v0.12.2 to v6.9.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   timezone:
     UTC
   node:
-    version: 0.12.2
+    version: 6.9.1
 deployment:
   production:
     branch: lang-ja


### PR DESCRIPTION
Circle CIでのテストが https://circleci.com/gh/vuejs/jp.vuejs.org/523 から失敗になってしまっているようです。

これは依存しているパッケージ (が依存しているパッケージ) が`const`宣言を使っているために起きているので依存しているパッケージのバージョンを固定したりするのが正しい解決方法な気はしますが、`const`宣言に対応しているNode.js v6.9.1は現在LTSになっているので入れ換えてしまって良いのではないかなと思っています。