### PR TITLE
Fix translation todomvc.md

### DIFF
--- a/src/v2/examples/todomvc.md
+++ b/src/v2/examples/todomvc.md
@@ -6,6 +6,6 @@ order: 9
 
 > これは Javascript の実質 120 行を切る(コメントと空行を除く)完全に仕様に準拠する TodoMVC 実装です。
 
-<p class="tip">あなたの Web ブラウザで 3rd-party データ/クッキーをブロックするよう設定している場合、`localeStorage` データは JSFiddle からの保存が失敗するため、以下の example は動作しない可能性があります。その場で結果を確認するためには、JSFiddle での Edit でクリックしなければなりません。</p>
+<p class="tip">あなたの Web ブラウザで 3rd-party データ/クッキーをブロックするよう設定している場合、`localeStorage` データは JSFiddle からの保存が失敗するため、以下の example は動作しない可能性があります。その場で結果を確認するためには、`Edit in JSFiddle` をクリックしなければなりません。</p>
 
 <iframe width="100%" height="500" src="https://jsfiddle.net/yyx990803/4dr2fLb7/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
訳しすぎの箇所を元に戻す