### PR TITLE
コードサンプル中でダブルクオートの中でダブルクオートが使われている箇所の修正

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -200,5 +200,5 @@ data: {
 2.3 から style プロパティに複数の (接頭辞付き) 値の配列を設定できます。例えば次のようになります:
 
 ``` html
-<div :style="{ display: ["-webkit-box", "-ms-flexbox", "flex"] }">
+<div :style="{ display: ['-webkit-box', '-ms-flexbox', 'flex'] }">
 ```


### PR DESCRIPTION
http://jp.vuejs.org/v2/guide/class-and-style.html#複数の値 での例で、ダブルクオートの中でダブルクオートが使われていてinvalidなテンプレートになっていたのを修正しました。

確認したところ、元の英語ドキュメントも同じようになっているようです。

