### PR TITLE
Change parenthesis position

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -1,6 +1,6 @@
 ---
 title: Vue インスタンス
-updated: 2017-07-15
+updated: 2017-08-22
 type: guide
 order: 3
 ---

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -74,7 +74,7 @@ vm.$watch('a', function (newVal, oldVal) {
 ```
 
 
-<p class="tip">インスタンスプロパティまたはコールバック(例: `vm.$watch('a', newval => this.myMethod())`) 上で[アロー関数](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) を使用しないでください。アロー関数は親コンテキストに束縛されるため、`this` は期待どおりに Vue インスタンスにならず、そして `this.myMethod` は undefined になります。</p>
+<p class="tip">インスタンスプロパティまたはコールバック上で[アロー関数](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) を使用しないでください(例: `vm.$watch('a', newval => this.myMethod())`) 。アロー関数は親コンテキストに束縛されるため、`this` は期待どおりに Vue インスタンスにならず、そして `this.myMethod` は undefined になります。</p>
 
 インスタンスの全てのプロパティとメソッドのリストは、 [API リファレンス](../api/#インスタンスプロパティ) を参照してください。
 


### PR DESCRIPTION
括弧書きの位置を変更しました。

Before:
インスタンスプロパティまたはコールバック(例: vm.$watch('a', newval => this.myMethod())) 上でアロー関数 を使用しないでください。

After:
インスタンスプロパティまたはコールバック上でアロー関数 を使用しないでください(例: vm.$watch('a', newval => this.myMethod())) 。
