### PR TITLE
Webpackについてのドキュメントの参照先を更新 #c8aef5e

### DIFF
--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -61,7 +61,7 @@ order: 19
 
 これらのリソースに没頭した後は、 [webpack-simple](https://github.com/vuejs-templates/webpack-simple) テンプレートを確認することをお勧めします。手順に沿って学習することで、あっという間に ES2015 とホットリローディングで動作した `.vue` コンポーネントの Vue プロジェクトを持っているはずです！
 
-テンプレートでは、多数の"モジュール"を取りまとめ最終的なアプリケーションに束ねてくれる [Webpack](https://webpack.js.org/) というモジュールバンドラーを使用します。 Webpack についてもっと学ぶには、[彼らの公式なドキュメント](https://webpack.js.org/configuration/)や [Webpack Academy](https://webpack.academy/p/the-core-concepts) を参照すると良いでしょう。
+テンプレートでは、多数の"モジュール"を取りまとめ最終的なアプリケーションに束ねてくれる [Webpack](https://webpack.js.org/) というモジュールバンドラーを使用します。 Webpack についてもっと学ぶには、[それらの公式なドキュメント](https://webpack.js.org/configuration/)や [Webpack Academy](https://webpack.academy/p/the-core-concepts) を参照すると良いでしょう。
 
 Webpack で、各モジュールは、バンドルに含まれる前に "loader" により変換されます。また Vue では `.vue` 単一ファイルコンポーネントをコンパイルするために [vue-loader](https://github.com/vuejs/vue-loader) を推奨しています。 [webpack-simple](https://github.com/vuejs-templates/webpack-simple) テンプレートはあなたのために全てセットアップ済みの状態で用意してありますが、もし Webpack と `.vue` コンポーネントについてもっと学びたい場合は、[vue-loader ドキュメント](https://vue-loader.vuejs.org) を読むこともできます。
 

--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -61,7 +61,7 @@ order: 19
 
 これらのリソースに没頭した後は、 [webpack-simple](https://github.com/vuejs-templates/webpack-simple) テンプレートを確認することをお勧めします。手順に沿って学習することで、あっという間に ES2015 とホットリローディングで動作した `.vue` コンポーネントの Vue プロジェクトを持っているはずです！
 
-テンプレートでは、多数の"モジュール"を取りまとめ最終的なアプリケーションに束ねてくれる [Webpack](https://webpack.js.org/) というモジュールバンドラーを使用します。 Webpack についてもっと学ぶには、 [このビデオ](https://www.youtube.com/watch?v=WQue1AN93YU) がとても良い導入となります。一度基本を終えてしまえば、[Egghead.io 上の上級 Webpack コース](https://egghead.io/courses/using-webpack-for-production-javascript-applications)もチェックしたくなるでしょう。
+テンプレートでは、多数の"モジュール"を取りまとめ最終的なアプリケーションに束ねてくれる [Webpack](https://webpack.js.org/) というモジュールバンドラーを使用します。 Webpack についてもっと学ぶには、[彼らの公式なドキュメント](https://webpack.js.org/configuration/)や [Webpack Academy](https://webpack.academy/p/the-core-concepts) を参照すると良いでしょう。
 
 Webpack で、各モジュールは、バンドルに含まれる前に "loader" により変換されます。また Vue では `.vue` 単一ファイルコンポーネントをコンパイルするために [vue-loader](https://github.com/vuejs/vue-loader) を推奨しています。 [webpack-simple](https://github.com/vuejs-templates/webpack-simple) テンプレートはあなたのために全てセットアップ済みの状態で用意してありますが、もし Webpack と `.vue` コンポーネントについてもっと学びたい場合は、[vue-loader ドキュメント](https://vue-loader.vuejs.org) を読むこともできます。
 


### PR DESCRIPTION
## origin

https://github.com/vuejs/vuejs.org/commit/c8aef5e9511c52263f79820c65b5d25c1ff2b27f

## Description

Webpack周りのドキュメントのリンクの更新に追従しました。