### PR TITLE
Typo

### DIFF
--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -352,6 +352,7 @@ new Vue({
     }
   }
 })
+
 function valueToPoint (value, index, total) {
   var x     = 0
   var y     = -value * 0.9
@@ -362,6 +363,7 @@ function valueToPoint (value, index, total) {
   var ty    = x * sin + y * cos + 100
   return { x: tx, y: ty }
 }
+
 function generatePoints (stats) {
   var total = stats.length
   return stats.map(function (stat, index) {
@@ -549,4 +551,3 @@ Sarah Drasner は以下のデモでタイマーとインタラクティブ駆動
 
 <p data-height="265" data-theme-id="light" data-slug-hash="YZBGNp" data-default-tab="result" data-user="sdras" data-embed-version="2" data-pen-title="Vue-controlled Wall-E" class="codepen">Pen を見る <a href="https://codepen.io/sdras/pen/YZBGNp/">Vue-controlled Wall-E</a> by Sarah Drasner (<a href="https://codepen.io/sdras">@sdras</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
-

--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -1,6 +1,6 @@
 ---
 title: 状態のトランジション
-updated: 2017-09-03
+updated: 2017-09-23
 type: guide
 order: 202
 ---


### PR DESCRIPTION
Cherry-picked from
https://github.com/vuejs/vuejs.org/commit/47d244bf2126927a5fe5aa04ec0e6c6a20f37c1d

日本語訳で`CSS-in-JSS`と記載している箇所はありませんでした。
L.355とL.366は差異があったので、元の修正とは関係ありませんが、この修正に取り込みました。