### PR TITLE
reorganize main menu

### DIFF
--- a/themes/vue/layout/partials/learn_dropdown.ejs
+++ b/themes/vue/layout/partials/learn_dropdown.ejs
@@ -1,5 +1,5 @@
 <li class="nav-dropdown-container learn">
-  <a class="nav-link<%- page.path.match(/(guide(?!\/team.html$)|api|examples|cookbook)/) ? ' current' : '' %>">習得</a><span class="arrow"></span>
+  <a class="nav-link<%- page.path.match(/(guide(?!\/team.html$)|api|examples|cookbook)/) ? ' current' : '' %>">学ぶ</a><span class="arrow"></span>
   <ul class="nav-dropdown">
     <li><ul>
       <li><a href="<%- url_for("/v2/guide/") %>" class="nav-link<%- page.path.match(/guide/) ? ' current' : '' %>">ガイド</a></li>

--- a/themes/vue/layout/partials/learn_dropdown.ejs
+++ b/themes/vue/layout/partials/learn_dropdown.ejs
@@ -1,0 +1,10 @@
+<li class="nav-dropdown-container learn">
+  <a class="nav-link<%- page.path.match(/(guide(?!\/team.html$)|api|examples|cookbook)/) ? ' current' : '' %>">習得</a><span class="arrow"></span>
+  <ul class="nav-dropdown">
+    <li><ul>
+      <li><a href="<%- url_for("/v2/guide/") %>" class="nav-link<%- page.path.match(/guide/) ? ' current' : '' %>">ガイド</a></li>
+      <li><a href="<%- url_for("/v2/api/") %>" class="nav-link<%- page.path.match(/api/) ? ' current' : '' %>">API</a></li>
+      <li><a href="<%- url_for("/v2/examples/") %>" class="nav-link<%- page.path.match(/examples/) ? ' current' : '' %>">例</a></li>
+    </ul></li>
+  </ul>
+</li>

--- a/themes/vue/layout/partials/main_menu.ejs
+++ b/themes/vue/layout/partials/main_menu.ejs
@@ -3,12 +3,13 @@
     <input type="text" id="search-query-<%- context %>" class="search-query st-default-search-input">
   </form>
 </li>
-<li><a href="<%- url_for("/v2/guide/") %>" class="nav-link<%- page.path.match(/guide/) ? ' current' : '' %>">ガイド</a></li>
-<li><a href="<%- url_for("/v2/api/") %>" class="nav-link<%- page.path.match(/api/) ? ' current' : '' %>">API</a></li>
-<li><a href="<%- url_for("/v2/examples/") %>" class="nav-link<%- page.path.match(/examples/) ? ' current' : '' %>">例</a></li>
-<li><a href="/contribution/" class="nav-link<%- page.path.match(/contribution/) ? ' current' : '' %>">貢献</a></li>
+<%- partial('partials/learn_dropdown') %>
 <%- partial('partials/ecosystem_dropdown') %>
-<%- partial('partials/language_dropdown') %>
 <li>
-  <a href="https://vue.threadless.com" target="_blank" class="nav-link shop">ショップ</a>
+  <a href="<%- url_for("/v2/guide/team.html") %>" class="nav-link team<%- page.path.match(/team\.html/) ? ' current' : '' %>">チーム</a>
 </li>
+<li>
+  <a href="/contribution/" class="nav-link<%- page.path.match(/contribution/) ? ' current' : '' %>">貢献</a>
+</li>
+<%- partial('partials/support_vue_dropdown') %>
+<%- partial('partials/language_dropdown') %>

--- a/themes/vue/layout/partials/support_vue_dropdown.ejs
+++ b/themes/vue/layout/partials/support_vue_dropdown.ejs
@@ -1,10 +1,10 @@
 <li class="nav-dropdown-container support-vue">
-  <a class="nav-link">Vue をサポートする</a><span class="arrow"></span>
+  <a class="nav-link">Vue を支援する</a><span class="arrow"></span>
   <ul class="nav-dropdown">
     <li><ul>
       <li><a href="https://vue.threadless.com" target="_blank" class="nav-link">ショップ</a></li>
-      <li><a href="https://opencollective.com/vuejs" target="_blank" class="nav-link">OpenCollective でサポートする</a></li>
-      <li><a href="https://www.patreon.com/evanyou" target="_blank" class="nav-link">Patreon で Evan をサポートする</a></li>
+      <li><a href="https://opencollective.com/vuejs" target="_blank" class="nav-link">OpenCollective で支援する</a></li>
+      <li><a href="https://www.patreon.com/evanyou" target="_blank" class="nav-link">Patreon で Evan を支援する</a></li>
     </ul></li>
   </ul>
 </li>

--- a/themes/vue/layout/partials/support_vue_dropdown.ejs
+++ b/themes/vue/layout/partials/support_vue_dropdown.ejs
@@ -1,0 +1,10 @@
+<li class="nav-dropdown-container support-vue">
+  <a class="nav-link">Vue をサポートする</a><span class="arrow"></span>
+  <ul class="nav-dropdown">
+    <li><ul>
+      <li><a href="https://vue.threadless.com" target="_blank" class="nav-link">ショップ</a></li>
+      <li><a href="https://opencollective.com/vuejs" target="_blank" class="nav-link">OpenCollective でサポートする</a></li>
+      <li><a href="https://www.patreon.com/evanyou" target="_blank" class="nav-link">Patreon で Evan をサポートする</a></li>
+    </ul></li>
+  </ul>
+</li>

--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -131,12 +131,12 @@ a.button
       .arrow
         pointer-events none
     .nav-link
-      &:hover
+      &:hover:not(.current)
         border-bottom: none
     &:hover
       .nav-dropdown
         display: block
-    &.language
+    &.language, &.ecosystem
       margin-left: 20px
     .arrow
       pointer-events: none

--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -52,8 +52,25 @@ body.docs
   padding-bottom: 3px
   &:hover, &.current
     border-bottom: 3px solid $green
-  &.shop
+  &.team
     margin-left: 10px
+
+.nav-dropdown
+  .nav-link
+    &:hover, &.current
+      border-bottom: none
+    &.current
+      &::after
+        content: ''
+        width: 0
+        height: 0
+        border-left: 5px solid $green
+        border-top: 3px solid transparent
+        border-bottom: 3px solid transparent
+        position: absolute;
+        top: 50%;
+        margin-top: -4px;
+        left: 8px;
 
 .new-label
   position: absolute


### PR DESCRIPTION
Cherry-picked from
https://github.com/vuejs/vuejs.org/commit/5fad4df2cf1b2bf6bfeed429557d8d211a7eb254

補足：ヘッダーに表示される「貢献」の位置を変えています

現状を維持しようとすると、こんな感じで詰まってしまう
<img width="536" alt="screen shot 2017-10-01 at 13 22 00" src="https://user-images.githubusercontent.com/3705391/31051740-9bc21768-a6ab-11e7-9a2e-ab697fbc3572.png">

CSSをいじりたくなかったので、見栄えが悪くならない位置に移動
<img width="538" alt="screen shot 2017-10-01 at 13 21 30" src="https://user-images.githubusercontent.com/3705391/31051739-98b64026-a6ab-11e7-9434-d77a46c758ad.png">