### PR TITLE
Remove build restriction on a specific branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,3 @@ deployment:
       - ./node_modules/.bin/hexo generate
       - cp -R ./todomvc public/examples
       - ./node_modules/.bin/hexo deploy
-general:
-  branches:
-    only:
-      - lang-ja


### PR DESCRIPTION
`lang-ja`にmergeしてからlintで落ちるケースをたまに見るので、
pull requestをmergeする前にCircle CIでテストが走ると良さそうです。

そのために、`lang-ja`以外もビルドするよう設定を変えました。
merge後、Circle CIのプロジェクト設定から`Only build pull requests`を有効化すると、
`lang-ja`とpull requestのbranchのみをビルド対象にすることができます。
https://circleci.com/gh/vuejs/jp.vuejs.org/edit#advanced-settings