### PR TITLE
delete sponsor link

### DIFF
--- a/src/support-vuejs/index.md
+++ b/src/support-vuejs/index.md
@@ -50,8 +50,6 @@ Vue.js は MIT ライセンスのオープンソース・プロジェクトで�
     <img src="/images/tmvuejs2.png">
   </a><a href="https://component.io" target="_blank" style="width: 140px;">
     <img src="/images/component_io.png" style="width: 140px;">
-  </a><a href="https://www.v2ex.com/t/379389" target="_blank" style="width: 120px;">
-    <img src="/images/v2exer.png" style="width: 120px;">
   </a><a href="https://www.xfive.co/" target="_blank" style="width: 80px;">
     <img src="/images/xfive.png" style="width: 80px;">
   </a><a href="http://www.frontenddevelopermeetups.com/" target="_blank" style="width: 120px;">

--- a/themes/vue/layout/partials/sponsors.ejs
+++ b/themes/vue/layout/partials/sponsors.ejs
@@ -38,9 +38,6 @@
 <a href="https://component.io" target="_blank" style="width: 120px; top: 1px;">
   <img src="<%- url_for("/images/component_io.png") %>" style="width: 120px;">
 </a>
-<a href="https://www.v2ex.com/t/379389" target="_blank" style="width: 100px;">
-  <img src="<%- url_for("/images/v2exer.png") %>" style="width: 100px;">
-</a>
 <a href="https://www.xfive.co/" target="_blank" style="width: 65px;">
   <img src="<%- url_for("/images/xfive.png") %>" style="width: 65px;">
 </a>


### PR DESCRIPTION
トップページのスポンサー"https://www.v2ex.com/t/379389" の
アイコン画像が表示されていませんでした。

中文、Englishなど他言語のサイト確認したところ、
リンクそのものが無いので、不要かと思いました。
