### PR TITLE
Change Lint target to all `src/v2/` all children markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "deploy": "npm run build && hexo deploy",
     "precommit": "npm test",
     "test": "npm run lint",
-    "lint": "node -e \"var shell=require('shelljs');var files=shell.find(['./src/v2/guide/*.md','./src/v2/style-guide/*.md','./src/v2/api/*.md','./src/v2/examples/*.md','./src/_posts/*.md']).filter(function(file){return !file.endsWith('/guide/team.md')}).join(' ');if(shell.exec('textlint --rulesdir ./node_modules/textlint-checker-for-vuejs-jp-docs/rules/textlint-rule-vue-jp-docs -f pretty-error '+files).code!==0){shell.exit(1)};\""
+    "lint": "node -e \"var shell=require('shelljs');var files=shell.find(['./src/v2/**/*.md','./src/_posts/*.md']).filter(function(file){return !file.endsWith('/guide/team.md')}).join(' ');if(shell.exec('textlint --rulesdir ./node_modules/textlint-checker-for-vuejs-jp-docs/rules/textlint-rule-vue-jp-docs -f pretty-error '+files).code!==0){shell.exit(1)};\""
   }
 }

--- a/src/v2/cookbook/creating-custom-scroll-directives.md
+++ b/src/v2/cookbook/creating-custom-scroll-directives.md
@@ -106,12 +106,12 @@ Vue はディレクティブに対する豊富なオプションがあります�
 
 簡潔で読みやすいコードの維持に役立てるため、ページを下にスクロールするときにアニメーションの開始・終了座標といった定義済みの引数を渡したくなります。
 
-**この例は[フルスクリーンバージョン](https://s.codepen.io/sdras/debug/078c19f5b3ed7f7d28584da450296cd0)の方が見やすいです.**
+**この例は[フルスクリーンバージョン](https://s.codepen.io/sdras/debug/078c19f5b3ed7f7d28584da450296cd0)の方が見やすいです。**
 
 <p data-height="500" data-theme-id="5162" data-slug-hash="c8c55e3e0bba997350551dd747119100" data-default-tab="result" data-user="sdras" data-embed-version="2" data-pen-title="Scrolling Example- Using Custom Directives in Vue" class="codepen">See the Pen <a href="https://codepen.io/sdras/pen/c8c55e3e0bba997350551dd747119100/">Scrolling Example- Using Custom Directives in Vue</a> by Sarah Drasner (<a href="https://codepen.io/sdras">@sdras</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
 
-上のデモのそれぞれのセクションには、スクロールによって引き起こされる2つの異なるアニメーションがあります。モーフィングアニメーションと、SVG内の個々のパスに沿って動く描画アニメーションです。これら2つのアニメーションを再利用するため、それぞれのカスタムディレクティブを作成します。カスタムディレクティブに渡す引数は、シンプルかつ再利用可能なコードの維持に役立ちます。
+上のデモのそれぞれのセクションには、スクロールによって引き起こされる 2 つの異なるアニメーションがあります。モーフィングアニメーションと、 SVG 内の個々のパスに沿って動く描画アニメーションです。これら 2 つのアニメーションを再利用するため、それぞれのカスタムディレクティブを作成します。カスタムディレクティブに渡す引数は、シンプルかつ再利用可能なコードの維持に役立ちます。
 
 やり方を示すために、モーフィングシェイプの例を見てみましょう。ここでは開始・終了座標の状態と共に、モーフィングを作成するパス値が必要です。これらの引数はそれぞれ `binding.value.foo` として定義されています。
 

--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -84,7 +84,7 @@ There are other methods of debugging, varying in complexity. The most popular an
 [Vuetron](http://vuetron.io/) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
 
 * Quickly view API Request/Response: if you're using the fetch API for requests, this event is displayed for any request sent. The expanded card displays the request data as well as the response data.
-* Subscribe to specific parts of your application’s state for faster debugging
+* Subscribe to specific parts of your application's state for faster debugging
 * Visualize component hierarchy, and an animation allows you to collapse or expand the tree for specific hierarchy views.
 
 ![Vuetron Heirarchy](/images/vuetron-heirarchy.gif)

--- a/src/v2/cookbook/form-validation.md
+++ b/src/v2/cookbook/form-validation.md
@@ -7,7 +7,7 @@ order: 3
 
 ## 基本的な例
 
-フォームのバリデーションはブラウザにネイティブサポートされていますが、異なるブラウザ間での取り扱いには注意が必要です。またバリデーションが完全にサポートされている場合であっても、カスタマイズしたバリデーションが必要な場合もあるため、 Vue ベースでのソリューションが適切かもしれません。簡単な例から見ていきましょう。
+フォームのバリデーションはブラウザにネイティブサポートされますが、異なるブラウザ間での取り扱いには注意が必要です。またバリデーションが完全にサポートされている場合においても、カスタマイズしたバリデーションが必要な場合もあるため、 Vue ベースでのソリューションが適切かもしれません。簡単な例から見ていきましょう。
 
 3 つのフィールドをもち、2 つが必須の場合。はじめに HTML を見てみましょう。
 
@@ -47,11 +47,11 @@ order: 3
 </form>
 ```
 
-そして、その HTML をラップしましょう。 `<form>` タグには、 Vue コンポーネントに使用する ID が存在します。フォーム送信のハンドラと `action` がありますが、一時的な URL であり、現実のサーバーのどこかを指しています(ここでは、サーバーサイドでのバリデーションをバックアップしています)。
+そして、その HTML をラップしましょう。 `<form>` タグには、 Vue コンポーネントに使用する ID が存在します。フォーム送信のハンドラと `action` がありますが、一時的な URL で、本来は現実のサーバーのどこかを指しています(ここでは、サーバーサイドでのバリデーションをバックアップしています)。
 
 その子には、エラーの状態にもとづいてそれ自身を表示・非表示とするための段落があります。これによって、フォーム上にシンプルなエラーのリストが表示されます。バリデーションはフィールドの変更時ではなく、フォーム送信の際に実行されることに注意してください。
 
-最後に、3つのフィールドそれぞれに対応、対応する `v-model`が存在し、これをJavaScriptで利用する値と紐付ける必要があります。その例を見てみましょう。
+最後に、 3 つのフィールドそれぞれに対応、対応する `v-model` が存在し、これを JavaScript で利用する値と紐付ける必要があります。その例を見てみましょう。
 
 ``` js
 const app = new Vue({
@@ -74,14 +74,14 @@ const app = new Vue({
 })
 ```
 
-短くてシンプルです。エラーを保持した上で、 3 つのフォームのフィールドに対して `null` を設定する配列を定義します。 `checkForm` のロジック(フォーム送信時に実行されるもの)では、 movie の値はオプショナルであるため、 name および age についてのみチェックしています。それぞれについて、空であればチェックをし、特定のエラーを設定するだけです。 以下のデモで実行してみることができます。なお、このデモでは送信が成功すると一時的な URL へと POST されることを忘れないでください。
+短くてシンプルです。エラーを保持した上で、 3 つのフォームのフィールドに対して `null` を設定する配列を定義します。 `checkForm` のロジック(フォーム送信時に実行されるもの)では、 movie の値はオプショナルなので、 name および age についてのみチェックしています。それぞれについて、空ならばチェックをし、特定のエラーを設定するだけです。 以下のデモで実行してみることができます。なお、このデモでは送信が成功すると一時的な URL へと POST されることを忘れないでください。
 
 <p data-height="265" data-theme-id="0" data-slug-hash="GObpZM" data-default-tab="html,result" data-user="cfjedimaster" data-embed-version="2" data-pen-title="form validation 1" class="codepen">See the Pen <a href="https://codepen.io/cfjedimaster/pen/GObpZM/">form validation 1</a> by Raymond Camden (<a href="https://codepen.io/cfjedimaster">@cfjedimaster</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 ## カスタムバリデーションの利用
 
-次の例では、２つめのテキストフィールドを email へと切り替え、カスタマイズしたロジックでバリデーションをします。このコードは、 StackOverflow の質問「[How to validate email address in JavaScript?](https://stackoverflow.com/questions/46155/how-to-validate-email-address-in-javascript)」から持ってきています。 HTML はこちらですが、はじめの例と非常に似通っています。
+次の例では、 2 つめのテキストフィールドを email へと切り替え、カスタマイズしたロジックでバリデーションをします。このコードは、 StackOverflow の質問「[How to validate email address in JavaScript?](https://stackoverflow.com/questions/46155/how-to-validate-email-address-in-javascript)」から持ってきています。 HTML はこちらですが、はじめの例と非常に似通っています。
 
 ``` html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
@@ -119,7 +119,7 @@ const app = new Vue({
 </form>
 ```
 
-ここでの変更は少しだけですが、トップのフォームに対して `novalidate="true"` に注目してください。 `type="email"` の場合、ブラウザがフィールドに入力された E メールアドレスをバリデーションしようするため、この設定は重要です。率直に言えば、この場合はブラウザを信用すべきかもしれませんが、ここではカスタムバリデーションのサンプルであるため無効化しています。 JavaScript 側の更新は以下になります:
+ここでの変更は少しだけですが、トップのフォームに対して `novalidate="true"` に注目してください。 `type="email"` の場合、ブラウザがフィールドに入力された E メールアドレスをバリデーションしようするため、この設定は重要です。率直に言えば、この場合はブラウザを信用すべきかもしれませんが、ここではカスタムバリデーションのサンプルのため無効化しています。 JavaScript 側の更新は以下になります:
 
 ``` js
 const app = new Vue({
@@ -157,7 +157,7 @@ const app = new Vue({
 
 ## カスタムバリデーションにおけるその他の例
 
-3 つめの例は、アンケートアプリにて見たことがあるかもしれません。ユーザーは、 戦艦のそれぞれの機能に対して予算を振り分ける必要があります。かつ合計は必ず 100 である必要があります。まずは HTMLです。
+3 つめの例は、アンケートアプリにて見たことがあるかもしれません。ユーザーは、 戦艦のそれぞれの機能に対して予算を振り分ける必要があります。かつ合計は必ず 100 となる必要があります。まずは HTML です。
 
 ``` html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
@@ -227,14 +227,14 @@ const app = new Vue({
 })
 ```
 
-合計値を算出プロパティとして設定し、バグを取り除いて動かすために十分に簡潔でした。 checkForm メソッドでは、合計値が 100 であるかどうかだけ確認する必要があります。こちらで実際に動作させることができます:
+合計値を算出プロパティとして設定し、バグを取り除いて動かすために十分に簡潔でした。 checkForm メソッドでは、合計値が 100 かどうかだけ確認する必要があります。こちらで実際に動作させることができます:
 
 <p data-height="265" data-theme-id="0" data-slug-hash="vWqGoy" data-default-tab="html,result" data-user="cfjedimaster" data-embed-version="2" data-pen-title="form validation 3" class="codepen">See the Pen <a href="https://codepen.io/cfjedimaster/pen/vWqGoy/">form validation 3</a> by Raymond Camden (<a href="https://codepen.io/cfjedimaster">@cfjedimaster</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>
 
 ## サーバーサイドでのバリデーション
 
-最後の例では、 Ajax を利用してサーバーにてバリデーションを行うものを作成しました。このフォームでは、新しい product の名前を尋ね、その名前が一意であることをチェックします。このバリデーションのために、サーバーレスな [OpenWhisk](http://openwhisk.apache.org/) アクションを書きました。ここでは重要ではありませんが、ロジックはこちらになります:
+最後の例では、 Ajax を利用してサーバーにてバリデーションを行うものを作成しました。このフォームでは、新しい product の名前を尋ね、その名前が一意かをチェックします。このバリデーションのために、サーバーレスな [OpenWhisk](http://openwhisk.apache.org/) アクションを書きました。ここでは重要ではありませんが、ロジックはこちらになります:
 
 ``` js
 function main(args) {
@@ -309,7 +309,7 @@ const app = new Vue({
 })
 ```
 
-OpenWhisk にて実行される API の URL を表す変数から始まります。 `checkForm` を見てみましょう。この例においては、フォームが送信されないようにしています(ただし、 HTML 上で Vue にて動かすことはできます). ここで、 `this.name` が空であるかのチェックを行い、その後 API を叩いていることが見てとれます。問題がある場合は、先ほどの例と同じようにエラーを追加しています。うまくいけば、なにもしません(ここではアラートのみ) URL に含まれる product の名前をもとに新しいページへと遷移させたり、他の動作を実行することもできます。以下でデモを実行できます:
+OpenWhisk にて実行される API の URL を表す変数から始まります。 `checkForm` を見てみましょう。この例においては、フォームが送信されないようにしています(ただし、 HTML 上で Vue にて動かすことはできます). ここで、 `this.name` が空かどうかのチェックを行い、その後 API を叩いていることが見てとれます。問題がある場合は、先ほどの例と同じようにエラーを追加しています。うまくいけば、なにもしません(ここではアラートのみ) URL に含まれる product の名前をもとに新しいページへと遷移させたり、他の動作を実行することもできます。以下でデモを実行できます:
 
 <p data-height="265" data-theme-id="0" data-slug-hash="BmgzeM" data-default-tab="js,result" data-user="cfjedimaster" data-embed-version="2" data-pen-title="form validation 4" class="codepen">See the Pen <a href="https://codepen.io/cfjedimaster/pen/BmgzeM/">form validation 4</a> by Raymond Camden (<a href="https://codepen.io/cfjedimaster">@cfjedimaster</a>) on <a href="https://codepen.io">CodePen</a>.</p>
 <script async src="https://production-assets.codepen.io/assets/embed/ei.js"></script>


### PR DESCRIPTION
## About

TextLint の対象を拡大し、 Cookbook を含む全ての `/src/v2` 以下のマークダウンを対象としました。
lang-ja ブランチをグリーンに保つため、これにあたって発生したエラーの対応もここで行っております。

@re-fort @kazupon 
どちらかご確認いただけると！