### PR TITLE
Update conrtibutor name

### DIFF
--- a/themes/vue/layout/partials/contribution.ejs
+++ b/themes/vue/layout/partials/contribution.ejs
@@ -158,7 +158,7 @@
     'kadoppe',
     'schwalbe10',
     'ise',
-    'laco0416',
+    'lacolaco',
     'kmiya',
     'tadyjp',
     'y-hara623',


### PR DESCRIPTION
貢献ページにいる ID 変更によってリンク切れとなったユーザー(下記スクリーンショット参照)について、本人に同一性を確認した上で新しい ID へと書き換えました。

![screen shot 2018-05-29 at 23 24 37](https://user-images.githubusercontent.com/6993514/40665188-9051ed50-6397-11e8-958b-e4af67b4fe45.png)
