### PR TITLE
Remove hexo-cli global install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 ## 開発
 
 ```sh
-$ npm install -g hexo-cli
 $ npm install
 $ npm start # http://localhost:4000 で開発サーバを開始
 ```


### PR DESCRIPTION
## About

今のバージョンでは特に hexo-cli は必要なく、人によっては「グローバルへのインストール」という部分が貢献の抵抗になるかも知れないためステップを削除した。

![screen shot 2018-09-27 at 0 49 05](https://user-images.githubusercontent.com/6993514/46092166-41cb7f00-c1ef-11e8-9e63-0ea69e2bc125.png)
