### PR TITLE
Fix root domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ language:
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: https://vuejs.org
+url: https://jp.vuejs.org
 root: /
 permalink: :year/:month/:day/:title/
 tag_dir: tags

--- a/themes/vue/_config.yml
+++ b/themes/vue/_config.yml
@@ -1,6 +1,6 @@
 site_description: "Vue.js - The Progressive JavaScript Framework"
 google_analytics: UA-46852172-1
-root_domain: vuejs.org
+root_domain: jp.vuejs.org
 vue_version: 2.5.16
 
 platinum_sponsors_china:


### PR DESCRIPTION
設定ファイルに書かれたroot domainが間違っていてRSSで配信される記事がリンク切れになっていたので修正しました.

## 変更によって影響を受けると思われる箇所
- `https://jp.vuejs.org/atom.xml` で配信される記事のURLが正しいものになります
  - 例: `Vue.js における次のイテレーションの計画`
    - Before: <https://vuejs.org/2018/10/01/plans-for-the-next-iteration-of-vue-js/>
    - After: <https://jp.vuejs.org/2018/10/01/plans-for-the-next-iteration-of-vue-js/>
- テンプレート内で `theme.root_domain` でドメインを参照している箇所の挙動が変わるかもしれません
  - [/themes/vue/layout/layout.ejs#L73](https://github.com/mizdra/jp.vuejs.org/blob/fix-root-domain/themes/vue/layout/layout.ejs#L73) など