### PR TITLE
note explicitly that v-bind.sync cannot be used with expressions

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -159,6 +159,8 @@ this.$emit('update:title', newTitle)
 <text-document v-bind:title.sync="doc.title"></text-document>
 ```
 
+<p class="tip">式で<code>.sync</code> 修飾子を <code>v-bind</code> と一緒に使うと機能<strong>しない</strong>ことに注意してください (例: <code>v-bind:title.sync="doc.title + '!'"</code> は無効です)。そうではなく、 <code>v-model</code> と同様にバインドしたいプロパティ名のみを指定してください。</p>
+
 `.sync` 修飾子を `v-bind` に付けることでオブジェクトを使って複数のプロパティを一度にセットする事ができます：
 
 ```html

--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -1,6 +1,6 @@
 ---
 title: カスタムイベント
-updated: 2018-05-08
+updated: 2018-10-24
 type: guide
 order: 103
 ---


### PR DESCRIPTION
## 概要
resolve #1279

## 補足
Original:https://github.com/vuejs/vuejs.org/commit/7800199011780a7ee1f42ac1749fea9da9889439
deploy preview: https://deploy-preview-1303--vuejs-jp.netlify.com/v2/guide/components-custom-events.html