### PR TITLE
翻訳の修正

### DIFF
--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -59,7 +59,7 @@ order: 402
 
 `.vue` コンポーネントにより、高度な JavaScript アプリケーションの分野に入っていきます。これはあなたがまだ使ったことのない、いくつかの追加ツールの使い方を学ぶことを意味します。
 
-- **Node Package Manager (NPM)**: [Getting Started guide](https://docs.npmjs.com/getting-started/what-is-npm) のセクション _10: Uninstalling global packages_ を読んでください。
+- **Node Package Manager (NPM)**: [Getting Started guide](https://docs.npmjs.com/getting-started/what-is-npm) のセクション _10: Uninstalling global packages_ までを読んでください。
 
 - **Modern JavaScript with ES2015/16**: Babel の [Learn ES2015 guide](https://babeljs.io/docs/learn-es2015/) を読んでください。現状では全ての機能を暗記する必要はないですが、参考として戻れるようにしておいてください。
 

--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -1,6 +1,6 @@
 ---
 title: 単一ファイルコンポーネント
-updated: 2018-10-15
+updated: 2018-11-7
 type: guide
 order: 402
 ---


### PR DESCRIPTION
## 概要
小さな所ですが、原文と意味が異なっていそうな箇所があったため修正しました。

## 補足
npmを学ぶ際の参考文献として、原文では
```
Node Package Manager (NPM): Read the Getting Started guide through section 10: Uninstalling global packages.
```
と記載されていたため、"セクション10**まで**"という文言に修正しました。