### PR TITLE
イベント装飾子の項目のtypo修正

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -220,7 +220,7 @@ Vue は [`addEventListener` の `passive` オプション](https://developer.moz
 
 `.passive` 修飾子は特にモバイルでのパフォーマンスを改善するのに有用です。
 
-<p class="tip">`.passive` と `.prevent` を一緒に使わないでください。`.prevent` は無視され、ブラウザにはおそらく警告が表示されます。`.passive` はイベントのデフォルトの挙動を妨げ_ない_ことをブラウザに伝達することを思い出してください。</p>
+<p class="tip">`.passive` と `.prevent` を一緒に使わないでください。`.prevent` は無視され、ブラウザにはおそらく警告が表示されます。`.passive` はイベントのデフォルトの挙動を妨げないことをブラウザに伝達することを思い出してください。</p>
 
 ## キー修飾子
 


### PR DESCRIPTION
## 概要
イベントハンドリングのイベント修飾子の項目に不要な`_`がありましたので削除させていただきました:bow:
https://jp.vuejs.org/v2/guide/events.html#%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E4%BF%AE%E9%A3%BE%E5%AD%90

## 補足
修正後は以下となっております。(`_`のみ削除)
<img width="824" alt="2018-11-24 21 27 55" src="https://user-images.githubusercontent.com/35585323/48968233-e02d6280-f02f-11e8-9f5b-af5cde10ee49.png">
