### PR TITLE
描画関数のちょっとした修正

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -1,6 +1,6 @@
 ---
 title: 描画関数とJSX
-updated: 2018-05-08
+updated: 2018-12-15
 type: guide
 order: 303
 ---
@@ -172,7 +172,7 @@ createElement(
 ``` js
 {
   // `v-bind:class` と同じ API、いずれかを受け付ける
-  // 文字列、オブジェクトまたは文字列の配列かつオブジェクト
+  // 文字列、オブジェクトまたは文字列とオブジェクトの配列
   class: {
     foo: true,
     bar: false


### PR DESCRIPTION
## 概要

`// a string, object, or array of strings and objects.`
に対して
`// 文字列、オブジェクトまたは文字列の配列かつオブジェクト`
は訳ミスかなと思いました。

## 補足

#### vuejs.org
https://github.com/vuejs/vuejs.org/commit/3afbcd01cad176eff73657c30126c8306db3c1ae#diff-ace1797ab50ff7853f4e2848d698e3d0R174

#### jp.vuejs.org
https://github.com/vuejs/jp.vuejs.org/commit/4c6d3c2c9f3b06605f6215b3d7f3e8e30418dd78#diff-ace1797ab50ff7853f4e2848d698e3d0R175