### PR TITLE
Translate misc updates

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -1,6 +1,6 @@
 ---
 title: プロパティ
-updated: 2018-12-08
+updated: 2019-02-04
 type: guide
 order: 102
 ---
@@ -314,7 +314,7 @@ Vue.component('my-component', {
 
 ```js
 {
-  class: 'username-input',
+  required: true,
   placeholder: 'Enter your username'
 }
 ```
@@ -338,12 +338,14 @@ Vue.component('base-input', {
 })
 ```
 
+<p class="tip">`inheritAttrs: false` オプションは、`style` および `class` 属性のバインディングには影響 **しない** ことに注意してください。</p>
+
 このパターンを使用すると、ルート上にある要素を気にすることなく、生の HTML 要素のように基底コンポーネントを利用できます。
 
 ```html
 <base-input
   v-model="username"
-  class="username-input"
+  required
   placeholder="Enter your username"
 ></base-input>
 ```

--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -1,7 +1,7 @@
 ---
 title: スロット
 type: guide
-updated: 2019-01-30
+updated: 2019-02-04
 order: 104
 ---
 
@@ -214,7 +214,7 @@ Vue は現在の [Web Components spec draft](https://github.com/w3c/webcomponent
 </todo-list>
 ```
 
-> 2.5.0 以降では、`slot-scope` はもはや `<template>` に限定されず、どの要素やコンポーネントでも使用できます。
+> 2.5.0 より前では、`slot-scope` は `scope` という名前で、`<template>` 要素に制限されていました。2.5.0 以降では、`slot-scope` にこの制限がなくなり、どの要素やコンポーネントでも使用できます。
 
 ### `slot-scope` の分割代入
 


### PR DESCRIPTION
## 概要

* resolve #1429 
* resolve #1440 

## 補足

* [Doc]: Clarify that "slot-scope" is named "scope" before 2.5.0 #1429
    * cherry-pick & translate vuejs/vuejs.org@40f1880
* [Doc]: Add clarification about `inheritAttrs` and class/style bindings #1440
    * cherry-pick & translate vuejs/vuejs.org@1b68103