### PR TITLE
Fix missing link for v-once #1570

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -85,8 +85,9 @@
       'Inline-Templates':
         '/v2/guide/components-edge-cases.html#Inline-Templates',
       'X-Templates': '/v2/guide/components-edge-cases.html#X-Templates',
-      'Cheap-Static-Components-with-v-once':
-        '/v2/guide/components-edge-cases.html#Cheap-Static-Components-with-v-once'
+      // encodeURIComponent('v-once-を使用した安価な静的コンポーネント')
+      'v-once-%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%9F%E5%AE%89%E4%BE%A1%E3%81%AA%E9%9D%99%E7%9A%84%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88':
+        '/v2/guide/components-edge-cases.html#v-once-を使用するチープスタティックコンポーネント'
     })
     function checkForHashRedirect(pageRegex, redirects) {
       // Abort if the current page doesn't match the page regex


### PR DESCRIPTION
## 概要

* resolve #1570

## 動作確認

* `/v2/api/#v-once` の `コンポーネント - v-once による安価な静的コンポーネント` に対するリンクが動作すること

## 補足

* これまで使用していなかったcommon.jsによるリダイレクトの仕組みを用いた修正となります
* URLハッシュに日本語が含まれる場合は、URLエンコードした文字列をキーにする必要がある点に注意してください
* 他にも同様のリンク切れがありそうですが、数が多いのでこのPRのスコープ外とさせてください

