### PR TITLE
Translate 1589, 1590

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -2484,11 +2484,11 @@ updated: 2019-04-01
 ### transition
 
 - **プロパティ:**
-  - `name` - string、自動的に生成されるトランジション CSS クラス名で使用する。例: `name: 'fade'` は `.fade-enter`、`.fade-enter-active`などに自動で展開する。デフォルトは`"v"`
-  - `appear` - boolean、初期描画でのトランジションを適用するかどうか。デフォルトは `false`
-  - `css` - boolean、CSS トランジションクラスを提供するかどうか。デフォルトは `true`。`false` に設定する場合、コンポーネントイベント経由登録された JavaScript フックだけトリガする
-  - `type` - string、トランジションの終了タイミングを決定するためにトランジションイベントのタイプを指定する。利用可能な値は `"transition"`、`"animation"`。デフォルトでは自動的により長い時間を持つタイプを検出する
-  - `mode` - string、leaving/entering トランジションのタイミングシーケンスを制御する。利用可能なモードは、`"out-in"`、`"in-out"`。デフォルトは同時になる。
+  - `name` - string、自動的に生成されるトランジション CSS クラス名に使用します。例: `name: 'fade'` は `.fade-enter`、`.fade-enter-active` などに自動で展開します。デフォルトは `"v"` です。
+  - `appear` - boolean、初期描画でのトランジションを適用するかどうか。デフォルトは `false` です。
+  - `css` - boolean、CSS トランジションクラスを提供するかどうか。デフォルトは `true`。`false` に設定する場合、コンポーネントイベント経由登録された JavaScript フックだけトリガします。
+  - `type` - string、トランジションの終了タイミングを決定するためにトランジションイベントのタイプを指定します。利用可能な値は `"transition"` と `"animation"` です。デフォルトでは自動的により長い時間を持つタイプを検出します。
+  - `mode` - string、leaving/entering トランジションのタイミングシーケンスを制御します。利用可能なモードは、`"out-in"` と `"in-out"` です。デフォルトは同時になります。
   - `duration` - number | { `enter`: number, `leave`: number } トランジションの期間を指定します。デフォルトでは、Vue はルートのトランジション要素の最初の `transitionend` または `animationend` イベントを待ちます。
   - `enter-class` - string
   - `leave-class` - string

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1,7 +1,7 @@
 ---
 title: API
 type: api
-updated: 2019-03-29
+updated: 2019-04-01
 ---
 
 ## グローバル設定
@@ -2489,6 +2489,7 @@ updated: 2019-03-29
   - `css` - boolean、CSS トランジションクラスを提供するかどうか。デフォルトは `true`。`false` に設定する場合、コンポーネントイベント経由登録された JavaScript フックだけトリガする
   - `type` - string、トランジションの終了タイミングを決定するためにトランジションイベントのタイプを指定する。利用可能な値は `"transition"`、`"animation"`。デフォルトでは自動的により長い時間を持つタイプを検出する
   - `mode` - string、leaving/entering トランジションのタイミングシーケンスを制御する。利用可能なモードは、`"out-in"`、`"in-out"`。デフォルトは同時になる。
+  - `duration` - number | { enter: number, leave: number } トランジションの期間を指定します。デフォルトでは、Vue はルートのトランジション要素の最初の `transitionend` または `animationend` イベントを待ちます
   - `enter-class` - string
   - `leave-class` - string
   - `appear-class` - string

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -2489,7 +2489,7 @@ updated: 2019-04-01
   - `css` - boolean、CSS トランジションクラスを提供するかどうか。デフォルトは `true`。`false` に設定する場合、コンポーネントイベント経由登録された JavaScript フックだけトリガする
   - `type` - string、トランジションの終了タイミングを決定するためにトランジションイベントのタイプを指定する。利用可能な値は `"transition"`、`"animation"`。デフォルトでは自動的により長い時間を持つタイプを検出する
   - `mode` - string、leaving/entering トランジションのタイミングシーケンスを制御する。利用可能なモードは、`"out-in"`、`"in-out"`。デフォルトは同時になる。
-  - `duration` - number | { enter: number, leave: number } トランジションの期間を指定します。デフォルトでは、Vue はルートのトランジション要素の最初の `transitionend` または `animationend` イベントを待ちます
+  - `duration` - number | { `enter`: number, `leave`: number } トランジションの期間を指定します。デフォルトでは、Vue はルートのトランジション要素の最初の `transitionend` または `animationend` イベントを待ちます。
   - `enter-class` - string
   - `leave-class` - string
   - `appear-class` - string


### PR DESCRIPTION
## 概要

* resolve #1589 
* resolve #1590  

## 補足

* cherry-pick & translate vuejs/vuejs.org@01d9ea7
* cherry-pick & translate vuejs/vuejs.org@1b36bef

最初の2コミットだけが原文の翻訳で、どちらも2492行目の `- duration - number | { enter: ...` から始まる1行に対する修正です。3コミット目は2487-2491行目の文体が常体になっていたものを敬体に統一しています。