### PR TITLE
[Doc]: Update custom-directive.md #1615

### DIFF
--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -1,6 +1,6 @@
 ---
 title: カスタムディレクティブ
-updated: 2018-12-08
+updated: 2019-05-06
 type: guide
 order: 302
 ---
@@ -143,6 +143,37 @@ new Vue({
 })
 </script>
 {% endraw %}
+
+`ディレクティブの引数は動的にできます。例えば、`v-mydirective:argument=[dataproperty]` において、`argument` はディレクティブフックの *binding* パラメーターに *arg* プロパティとして割り当てられる文字列値、`dataproperty` は同じ *binding* パラメーターに *value* プロパティとして割り当てられるコンポーネントの data プロパティへの参照となります。ディレクティブフックが呼ばれると、*binding* パラメーターの *value* プロパティは `dataproperty` の値に応じて動的に変わります。
+
+動的引数を使ったカスタムディレクティブの例は次の通りです:
+
+```html
+<div id="app">
+  <p>Scroll down the page</p>
+  <p v-tack:left="[dynamicleft]">I’ll now be offset from the left instead of the top</p>
+</div>
+```
+
+```js
+Vue.directive('tack', {
+  bind(el, binding, vnode) {
+    el.style.position = 'fixed';
+    const s = (binding.arg == 'left' ? 'left' : 'top');
+    el.style[s] = binding.value + 'px';
+  }
+})
+
+// アプリケーションを開始
+new Vue({
+  el: '#app',
+  data() {
+    return {
+      dynamicleft: 500
+    }
+  }
+})
+```
 
 ## 関数による省略記法
 


### PR DESCRIPTION
## 概要

* resolve #1615
* cherry-pick & translate vuejs/vuejs.org@84a8dff

## 補足

訳自体は問題ないと思いますが、そもそもの原文がこれでよいのかが気にかかって放置しちゃってました。本家にIssueを立てるのがよいのか判断がつかなかったので、いったんここで相談させてください。

https://github.com/vuejs/vuejs.org/pull/2062 の元々の意図は、カスタムディレクティブの引数にもv2.6で導入された [動的引数](https://vuejs.org/v2/guide/syntax.html#Dynamic-Arguments) が使えるということを言いたかったのではないかと思います。その証拠に、元々のPRでは `v-my-directive:[foo]` といった説明が記載されています。

しかし、PRのレビュー指摘の中でサンプルが `v-tack:left="[dynamicleft]"` に変わっており、これだと単に `v-tack:left="dynamicleft"` と書いても同じはずなので、v2.6の動的引数というよりは振る舞いを動的に変更できるという例に過ぎない気がしています。同じ例を使うなら、↓こっちの方がイメージに近いと思います。

* https://jsfiddle.net/y0ftjLxs/

属性値の中でブラケットを使って `"[dynamicleft]"` と記載する場合も「動的引数」と呼ぶのであれば、単に私の理解不足なだけかもしれませんが、どう思われますか？

