### PR TITLE
Fix translation on sync modifier notice

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -160,7 +160,7 @@ this.$emit('update:title', newTitle)
 <text-document v-bind:title.sync="doc.title"></text-document>
 ```
 
-<p class="tip"><code>v-bind</code> に <code>.sync</code> 修飾子をつける場合は式を指定しても<strong>うまくいかない</strong>ことに注意してください (例: <code>v-bind:title.sync="doc.title + '!'"</code> は無効です)。そうではなく、 <code>v-model</code> と同様にバインドしたいプロパティ名のみを指定してください。</p>
+<p class="tip"><code>v-bind</code> に <code>.sync</code> 修飾子をつける場合は式を指定しても<strong>動作しない</strong>ことに注意してください (例: <code>v-bind:title.sync="doc.title + '!'"</code> は無効です)。そうではなく、 <code>v-model</code> と同様にバインドしたいプロパティ名のみを指定してください。</p>
 
 `.sync` 修飾子を `v-bind` に付けることでオブジェクトを使って複数のプロパティを一度にセットする事ができます：
 

--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -160,7 +160,7 @@ this.$emit('update:title', newTitle)
 <text-document v-bind:title.sync="doc.title"></text-document>
 ```
 
-<p class="tip">式で<code>.sync</code> 修飾子を <code>v-bind</code> と一緒に使うと機能<strong>しない</strong>ことに注意してください (例: <code>v-bind:title.sync="doc.title + '!'"</code> は無効です)。そうではなく、 <code>v-model</code> と同様にバインドしたいプロパティ名のみを指定してください。</p>
+<p class="tip"><code>v-bind</code> に <code>.sync</code> 修飾子をつける場合は式を指定しても<strong>うまくいかない</strong>ことに注意してください (例: <code>v-bind:title.sync="doc.title + '!'"</code> は無効です)。そうではなく、 <code>v-model</code> と同様にバインドしたいプロパティ名のみを指定してください。</p>
 
 `.sync` 修飾子を `v-bind` に付けることでオブジェクトを使って複数のプロパティを一度にセットする事ができます：
 


### PR DESCRIPTION
## 概要

sync 修飾子の注意点の訳を調整しました。

オリジナルのテキストは、

> Note that v-bind with the .sync modifier does not work with expressions

で、現状公開されている訳は

> 式で.sync 修飾子を v-bind と一緒に使うと機能しないことに注意してください

となっていますが、この説明だと「v-bind と .sync を組み合わせてはダメだ」というように読めてしまいました。このセクションでは v-bind に .sync を組み合わせることができることを紹介しているはずなのに、なぜかそれを真っ向から否定するような注意書きが付いているように見えてしまい、すぐに意味が理解できませんでした。

原文にあたってみたところ、「v-bind  と .sync を組み合わせると、式は指定できないよ」ということが書かれているのだと理解しました。ということで、そのニュアンスが正しく伝わるような言い回しに変えてみた次第です。

少し意訳気味にしてありますが、こんな感じでいかがでしょうか？