### PR TITLE
fix typo in custom-directive.md

### DIFF
--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -144,7 +144,7 @@ new Vue({
 </script>
 {% endraw %}
 
-`ディレクティブの引数は動的にできます。例えば、`v-mydirective:argument=[dataproperty]` において、`argument` はディレクティブフックの *binding* パラメーターに *arg* プロパティとして割り当てられる文字列値、`dataproperty` は同じ *binding* パラメーターに *value* プロパティとして割り当てられるコンポーネントの data プロパティへの参照となります。ディレクティブフックが呼ばれると、*binding* パラメーターの *value* プロパティは `dataproperty` の値に応じて動的に変わります。
+ディレクティブの引数は動的にできます。例えば、`v-mydirective:argument=[dataproperty]` において、`argument` はディレクティブフックの *binding* パラメーターに *arg* プロパティとして割り当てられる文字列値、`dataproperty` は同じ *binding* パラメーターに *value* プロパティとして割り当てられるコンポーネントの data プロパティへの参照となります。ディレクティブフックが呼ばれると、*binding* パラメーターの *value* プロパティは `dataproperty` の値に応じて動的に変わります。
 
 動的引数を使ったカスタムディレクティブの例は次の通りです:
 


### PR DESCRIPTION
## 概要

- *custom-directive.md* に typo があり、生成された HTML が原文と違ってしまっていたため修正しました

### before
![before](https://user-images.githubusercontent.com/706529/57837169-33bd8380-77fd-11e9-8117-9f90074c51cd.png)

### after
![after](https://user-images.githubusercontent.com/706529/57837180-38823780-77fd-11e9-8c55-9bd99dcfc3be.png)


## 補足

