### PR TITLE
[Doc]: chore(deps): bump js-yaml from 3.12.0 to 3.13.1 #1698

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,18 +2542,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1:
+js-yaml@^3.2.4, js-yaml@^3.3.1, js-yaml@^3.6.1, js-yaml@^3.9.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.2.4, js-yaml@^3.3.1, js-yaml@^3.6.1, js-yaml@^3.9.1:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## 概要

* resolve #1698

## 補足

* textlintなどがある関係でyarn.lockが本家のものとは若干違うので、cherry-pickではなく直接同様の修正を加えました
* 変更の前後で `yarn install & yarn build` を実行し、`public` ディレクトリ以下の出力に差分がないことを確認済みです
