### PR TITLE
fix: enforce `rel="noopener"` for external _blank targets

### DIFF
--- a/themes/vue/layout/partials/resources_dropdown.ejs
+++ b/themes/vue/layout/partials/resources_dropdown.ejs
@@ -3,6 +3,6 @@
   <ul class="nav-dropdown">
     <li><a href="<%- url_for("/resources/partners.html") %>" class="nav-link">パートナー</a></li>
     <li><a href="<%- url_for("/resources/themes.html") %>" class="nav-link">テーマ</a></li>
-    <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank">Awesome Vue</a></li>
+    <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank" rel="noopener">Awesome Vue</a></li>
   </ul>
 </li>

--- a/themes/vue/layout/search-page.ejs
+++ b/themes/vue/layout/search-page.ejs
@@ -12,7 +12,7 @@
           <strong>{{ totalResults }} results</strong> found in {{ queryTime }}ms
         </template>
       </p>
-      <a target="_blank" href="https://www.algolia.com/" aria-label="検索">
+      <a target="_blank" rel="noopener" href="https://www.algolia.com/" aria-label="検索">
           <img src="/images/search-by-algolia.png" height="16">
       </a>
     </div>


### PR DESCRIPTION
## 概要

resolves #1880 

<!-- 何か書くことがあれば追加メモを記入する -->

タイトルの通り、新タブ／ウィンドウで開かれる外部リンクは `rel="noopener"` を付けておきます。

<!-- メモ書きや Refs があれば書く。特に元のコミットへのリンクなどがあると助かります🙏 -->
