### PR TITLE
Added translation of "Annotating Props" #2103

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript のサポート
-updated: 2019-06-12
+updated: 2020-05-10
 type: guide
 order: 403
 ---

--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -187,3 +187,33 @@ const Component = Vue.extend({
 ```
 
 型推論やメンバの補完が機能していない場合、特定のメソッドにアノテーションを付けるとこれらの問題に対処できます。`--noImplicitAny` オプションを使用すると、これらのアノテーションが付けられていないメソッドの多くを見つけるのに役立ちます。
+
+## プロパティにアノテーションをつける
+
+```ts
+import Vue, { PropType } from 'vue'
+
+interface ComplexMessage { 
+  title: string,
+  okMessage: string,
+  cancelMessage: string
+}
+const Component = Vue.extend({
+  props: {
+    name: String,
+    success: { type: String },
+    callback: { 
+      type: Function as PropType<() => void>
+    },
+    message: {
+      type: Object as PropType<ComplexMessage>,
+      required: true,
+      validator (message: ComplexMessage) {
+        return !!message.title;
+      }
+    }
+  }
+})
+```
+
+バリデータが型推論できないかメンバの補完が機能していない場合、期待される型引数付きでアノテーションするとこれらの問題に対処できます。


### PR DESCRIPTION
## 概要

resolve #2103

「TypeScript のサポート」のページに「Annotating Props」の翻訳を追加しました

## 補足

Original: vuejs/vuejs.org@b97abcd

* "Props" を「プロパティ」と訳しました
  * `src/v2/guide/components-props.md` などに合わせました
  * 場所によっては `props` のままのところもあるようなのですが、プロパティの方がよいと判断しました
* `validator` を「バリデータ」と訳しました
  * `src/v2/guide/migration.md` に合わせました

よろしくお願いします。