### PR TITLE
動的引数の説明の箇所一部変更 （attributeName => attirbutename）

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -142,7 +142,7 @@ Mustache は、HTML 属性の内部で使用することはできません。代
 <a v-bind:[attributeName]="url"> ... </a>
 ```
 
-ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributeName` という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
+ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributename`（`attibuteName`ではない理由は下記　動的引数の式の制約にて説明） という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
 
 同様に、動的なイベント名にハンドラをバインドするために動的引数を使うこともできます:
 

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -142,7 +142,7 @@ Mustache は、HTML 属性の内部で使用することはできません。代
 <a v-bind:[attributeName]="url"> ... </a>
 ```
 
-ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributename`（`attibuteName`ではない理由は下記動的引数の式の制約にて説明） という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
+ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributename`（`attibuteName`ではない理由は下記動的引数の式の制約にて説明）という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
 
 同様に、動的なイベント名にハンドラをバインドするために動的引数を使うこともできます:
 

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -142,7 +142,7 @@ Mustache は、HTML 属性の内部で使用することはできません。代
 <a v-bind:[attributeName]="url"> ... </a>
 ```
 
-ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributename`（`attibuteName`ではない理由は下記　動的引数の式の制約にて説明） という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
+ここで `attributeName` は JavaScript 式として動的に評価され、その評価結果が引数の最終的な値として使われます。例えば、Vue インスタンスが `"href"` という値の `attributename`（`attibuteName`ではない理由は下記動的引数の式の制約にて説明） という data プロパティをもつ場合、このバインディングは `v-bind:href` と等しくなります。
 
 同様に、動的なイベント名にハンドラをバインドするために動的引数を使うこともできます:
 


### PR DESCRIPTION
# 概要
今回Vue.jsの勉強をドキュメントをみて実際にコードを書き進めていたのですが
動的引数の箇所で詰まったのでプルリク出してみました。

下までしっかりみると解決できるようになっているのですが
文通りに進めると実際に詰まってしまったので他にも詰まる方がいらっしゃる方がいるかもしれないので
変更のご検討の方よろしくお願いいたします。

```
<html>
    <head>
        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
    </head>
    <body>
      <div id="app">
        {{ message }}
        <a v-on:[attributeName]="doSomething">click</a>
      </div>
        <script>
          var app = new Vue({
            el: '#app',
            data: {
              message: "Hello Vue!",
              attributeName: "click" //<= こちらをキャメルケースにしてしまう。
            },
            methods: 
              doSomething: function () {
                this.message = this.message.split('').reverse().join('')
              }
            }
          })
        </script>
    </body>
</html>
```

実際にこのようなコードを書いてみて詰まってしまいました。
## 補足

- 対象ページ: https://jp.vuejs.org/v2/guide/syntax.html#%E5%8B%95%E7%9A%84%E5%BC%95%E6%95%B0

- 対象ファイル: https://github.com/vuejs/jp.vuejs.org/blob/lang-ja/src/v2/guide/syntax.md


