### PR TITLE
JTF日本語標準スタイルガイドのURLを変更

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Pull Request を送るときに、余裕があれば "resolve #123" といった
 
 ## 翻訳スタイル
 
-- [JTF日本語標準スタイルガイド（翻訳用）](https://www.jtf.jp/jp/style_guide/styleguide_top.html) に準拠
+- [JTF日本語標準スタイルガイド（翻訳用）](https://www.jtf.jp/tips/styleguide) に準拠
 - JTF日本語標準スタイルのチェックツールは [textlint-plugin-JTF-style](https://github.com/azu/textlint-plugin-JTF-style) を使用し、ルールはVue.js 公式サイト向けに[一部カスタマイズ](.textlintrc)
 
 


### PR DESCRIPTION
## 概要

Vue.js 公式サイト日本語翻訳ガイドに記載されている `JTF日本語標準スタイルガイド（翻訳用）`のリンクが変更されたようなので、新しい URL に修正しました。

## 補足

- 修正前
  - https://www.jtf.jp/jp/style_guide/styleguide_top.html （メンテナンス画面になっています）
- 修正後
  - https://www.jtf.jp/tips/styleguide