### PR TITLE
Vue 2.x is no more the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![Circle CI](https://circleci.com/gh/vuejs/jp.vuejs.org/tree/lang-ja.svg?style=svg&circle-token=833967ff387fa4a8d91a738086d5c166ea0a6f85)](https://circleci.com/gh/vuejs/jp.vuejs.org/tree/lang-ja)
 [![Slack Status](https://vuejs-jp-slackin.herokuapp.com/badge.svg)](https://vuejs-jp-slackin.herokuapp.com/)
 
-このリポジトリは Vue.js 最新バージョン 2.x 向けのドキュメントを管理しているレポジトリです。
+このリポジトリは Vue.js バージョン 2.x 向けのドキュメントを管理しているレポジトリです。
 
+- Vue.js 3.x 向けドキュメント管理リポジトリ: [こちら](https://github.com/vuejs-jp/ja.vuejs.org)
 - Vue.js 1.x 向けドキュメント管理リポジトリ: [こちら](https://github.com/vuejs/v1-jp.vuejs.org)
-- Vue.js 0.12 向けドキュメント管理リポジトリ: [こちら](https://github.com/vuejs-jp/012-jp.vuejs.org)
 
 このサイトは [hexo](https://hexo.io/) で構築されています。サイトコンテンツは `src` の位置に markdown フォーマットで書かれています。プルリクエスト、歓迎します！
 
@@ -25,4 +25,4 @@ $ npm start # http://localhost:4000 で開発サーバを開始
 このサイトは `lang-ja`にコミットまたはプルリクエストがマージされると[Netlify](https://www.netlify.com/)を介して、自動的にデプロイされます。
 
 ## 貢献者
-貢献された方々は、[こちら](http://jp.vuejs.org/contribution/) 
+貢献された方々は、[こちら](https://jp.vuejs.org/contribution/)


### PR DESCRIPTION
Vue 2.x is no more the latest version.

- Adds a link for v3 ja docs repo.
- Drops a link for v0.12 ja docs repo.
- `jp.vuejs.org` is now always on SSL.