### PR TITLE
Fix anchor  to "ES2015 の分割代入"

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -324,7 +324,7 @@ function (slotProps) {
 }
 ```
 
-これは、`v-slot` の値が関数定義の引数部分で有効な任意の JavaScript 式を受け付けることを意味します。そのため、サポートされている環境 ([単一ファイルコンポーネント](single-file-components.html) または [モダンブラウザ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E5%AE%9F%E8%A3%85%E7%8A%B6%E6%B3%81)) では、特定のスロットプロパティを取得するために [ES2015 の分割代入](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E5%88%86%E5%89%B2%E4%BB%A3%E5%85%A5) を使うこともできます:
+これは、`v-slot` の値が関数定義の引数部分で有効な任意の JavaScript 式を受け付けることを意味します。そのため、サポートされている環境 ([単一ファイルコンポーネント](single-file-components.html) または [モダンブラウザ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E5%AE%9F%E8%A3%85%E7%8A%B6%E6%B3%81)) では、特定のスロットプロパティを取得するために [ES2015 の分割代入](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#object_destructuring) を使うこともできます:
 
 ``` html
 <current-user v-slot="{ user }">
@@ -541,7 +541,7 @@ function (slotProps) {
 </slot-example>
 ```
 
-`slot-scope` の値は、関数定義の引数部分で有効な任意の JavaScript 式を受け付けることができます。これは、サポートされている環境 ([単一ファイルコンポーネント](single-file-components.html) または [モダンブラウザ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E5%AE%9F%E8%A3%85%E7%8A%B6%E6%B3%81)) では、式に [ES2015 の分割代入](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E5%88%86%E5%89%B2%E4%BB%A3%E5%85%A5) が使えることを意味します:
+`slot-scope` の値は、関数定義の引数部分で有効な任意の JavaScript 式を受け付けることができます。これは、サポートされている環境 ([単一ファイルコンポーネント](single-file-components.html) または [モダンブラウザ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E5%AE%9F%E8%A3%85%E7%8A%B6%E6%B3%81)) では、式に [ES2015 の分割代入](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#object_destructuring) が使えることを意味します:
 
 ``` html
 <slot-example>


### PR DESCRIPTION
>注意：このリポジトリは、Vue 2.x 用です。Vue 3.x の日本語翻訳に関連する Issue やプルリクエストは、別のリポジトリで管理されています: https://github.com/vuejs-jp/ja.vuejs.org

## 概要

対象のissueはない修正のPRです。

[スロットプロパティの分割代入](https://jp.vuejs.org/v2/guide/components-slots.html#%E3%82%B9%E3%83%AD%E3%83%83%E3%83%88%E3%83%97%E3%83%AD%E3%83%91%E3%83%86%E3%82%A3%E3%81%AE%E5%88%86%E5%89%B2%E4%BB%A3%E5%85%A5) の説明文に含まれる`ES2015 の分割代入` のリンクをクリックしたときにページが正しく表示されませんでした。URL中のアンカーの間違いだったようなので修正ました。
また、元のURLでgrepしたときにもう一箇所見つかったので、そちらも同様の修正を加えています。

リンク先のMDNのページの中で「オブジェクトの分割代入」の項目が表示されるのが正しいだろうというのは、修正前のURL並びに[英語版ドキュメントの同様の箇所の説明文](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots-with-the-slot-scope-Attribute)から判断しました。

<!-- 何か書くことがあれば追加メモを記入する -->

## 補足


<!-- メモ書きや Refs があれば書く。特に元のコミットへのリンクなどがあると助かります🙏 -->