### PR TITLE
fix: vuejs-jp slack join URL の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # vuejs/jp.vuejs.org
 
 [![Circle CI](https://circleci.com/gh/vuejs/jp.vuejs.org/tree/lang-ja.svg?style=svg&circle-token=833967ff387fa4a8d91a738086d5c166ea0a6f85)](https://circleci.com/gh/vuejs/jp.vuejs.org/tree/lang-ja)
-[![Slack Status](https://vuejs-jp-slackin.herokuapp.com/badge.svg)](https://vuejs-jp-slackin.herokuapp.com/)
 
 このリポジトリは Vue.js バージョン 2.x 向けのドキュメントを管理しているレポジトリです。
 

--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -5,7 +5,7 @@
     <li><ul>
       <li><a href="https://forum.vuejs.org/" class="nav-link" target="_blank" rel="noopener">フォーラム</a></li>
       <li><a href="https://chat.vuejs.org/" class="nav-link" target="_blank" rel="noopener">チャット(公式)</a></li>
-      <li><a href="https://vuejs-jp-slackin.herokuapp.com" class="nav-link" target="_blank" rel="noopener">チャット(日本向け)</a></li>
+      <li><a href="https://join.slack.com/t/vuejs-jp/shared_invite/zt-pcpd1rnq-QTaoQ0U_gRiewCsyO6NH8Q" class="nav-link" target="_blank" rel="noopener">チャット(日本向け)</a></li>
       <li><a href="https://events.vuejs.org/meetups/" class="nav-link" target="_blank" rel="noopener">ミートアップ</a></li>
     </ul></li>
     <li><h4>開発ツール</h4></li>


### PR DESCRIPTION
>注意：このリポジトリは、Vue 2.x 用です。Vue 3.x の日本語翻訳に関連する Issue やプルリクエストは、別のリポジトリで管理されています: https://github.com/vuejs-jp/ja.vuejs.org

## 概要

- Vue.js 日本ユーザーグループの Slack へ join するために用意していた、slackin が slack api で使用していた legacy api token が初期化？されてしまったため、join できない状態になっていた
- legacy api token の再発行を試みたが、現在 slack api はもうすでに発行出来ない状態になっているため、slackin が復旧できない状態に
- 現状 slackin は slack apps (現在 slack api は slack apps に登録が必須) に対応していないため、slack apps 経由で slack api を使って提供することはできない状態

## 対応方法
slack にユーザーを招待させるために、招待 URL を発行出来る仕組みが提供されているため、この方法で解決する

## 懸念点
発行した招待 URL の有効期限がはっきりしていない。招待 URL の設定で never expiration にしてあるが、発行されている招待 URL がnever になっているのかどうか分からない
