### PR TITLE
Add filename to example tsconfig.json

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -16,6 +16,7 @@ order: 403
 ## 推奨構成
 
 ``` js
+// tsconfig.json
 {
   "compilerOptions": {
     // これは Vue のブラウザサポートに合わせます


### PR DESCRIPTION
## 概要
元のリポジトリでは推奨環境の tsconfig.json の例にファイル名がコメントで記載されていましたが、日本語訳の方になかったので足しました。
https://github.com/vuejs/vuejs.org/blob/429fdee9b8264727664c782e31a19625c3af2a6e/src/v2/guide/typescript.md

## 補足
8f3fc8d369ff080ab9ad45b31221ad9590daec34 の段階では記述されていましたが、 ae9659d52c27a709de84ebe489c3447e948a9678 によって意図せず消えてしまったのではと推測しています。