### PR TITLE
Replace `v3.ja.vuejs.org` with `ja.vuejs.org`.

### DIFF
--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -10,7 +10,7 @@
 <div class="content <%- page.type ? page.type + ' with-sidebar' : '' %> <%- page.type === 'guide' ? page.path.replace(/.+\//, '').replace('.html', '') + '-guide' : '' %>">
   <p class="tip warning v3-warning">
     v2.x 以前のドキュメントです。
-    v3.x のドキュメントを見たい場合は<a href="https://v3.ja.vuejs.org/">こちら</a>
+    v3.x のドキュメントを見たい場合は<a href="https://ja.vuejs.org/">こちら</a>
   </p>
 
   <% if (page.type) { %>

--- a/themes/vue/layout/partials/header.ejs
+++ b/themes/vue/layout/partials/header.ejs
@@ -1,7 +1,7 @@
 <div>
   <div id="v3-banner">
     <span class="hidden-sm">v2.x 以前のドキュメントです。</span>
-    v3.x のドキュメントを見たい場合は<a href="https://v3.ja.vuejs.org/">こちら</a>
+    v3.x のドキュメントを見たい場合は<a href="https://ja.vuejs.org/">こちら</a>
   </div>
 
   <header id="header">

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -329,7 +329,7 @@
       var version = e.target.value
       var section = window.location.pathname.match(/\/v\d\/(\w+?)\//)[1]
       if (version === 'v3') {
-        window.location.assign('https://v3.ja.vuejs.org/' + section + '/')
+        window.location.assign('https://ja.vuejs.org/' + section + '/')
         return
       }
       if (version === 'SELF') { return }


### PR DESCRIPTION
>注意：このリポジトリは、Vue 2.x 用です。Vue 3.x の日本語翻訳に関連する Issue やプルリクエストは、別のリポジトリで管理されています: https://github.com/vuejs-jp/ja.vuejs.org

## 概要

このPRは「v3.x のドキュメントを見たい場合は[こちら]」のリンク先を `v3.ja.vuejs.org` から `ja.vuejs.org` に変更します。

## 補足

<!-- メモ書きや Refs があれば書く。特に元のコミットへのリンクなどがあると助かります🙏 -->
